### PR TITLE
Support rewinding small request bodies on redirect

### DIFF
--- a/java/com/google/net/cronet/okhttptransport/RequestBodyConverterImpl.java
+++ b/java/com/google/net/cronet/okhttptransport/RequestBodyConverterImpl.java
@@ -316,8 +316,8 @@ final class RequestBodyConverterImpl implements RequestBodyConverter {
       }
 
       return new UploadDataProvider() {
-        private volatile boolean isMaterialized = false;
-        private final Buffer materializedBody = new Buffer();
+        private byte[] materializedBody;
+        private int nextByteToRead;
 
         @Override
         public long getLength() {
@@ -326,35 +326,49 @@ final class RequestBodyConverterImpl implements RequestBodyConverter {
 
         @Override
         public void read(UploadDataSink uploadDataSink, ByteBuffer byteBuffer) throws IOException {
-          // We're not expecting any concurrent calls here so a simple flag should be sufficient.
-          if (!isMaterialized) {
-            requestBody.writeTo(materializedBody);
-            // The user (RequestBody#writeTo) is done writing the request body.
-            // At this point, the user might or might not have attempted to close the sink.
-            // However, since we're using an okio.Buffer, it doesn't matter. Because okio.Buffer
-            // is an in-memory buffer, and calling close() on it is a no-op. Furthermore, we don't
-            // need to flush() the buffer, because it is already in memory.
+          ensureMaterialized();
 
-            isMaterialized = true;
-            long reportedLength = getLength();
-            long actualLength = materializedBody.size();
-            if (actualLength != reportedLength) {
-              throw new IOException(
-                  "Expected " + reportedLength + " bytes but got " + actualLength);
-            }
-          }
-          if (materializedBody.read(byteBuffer) == -1) {
+          byte[] body = Verify.verifyNotNull(materializedBody);
+          int bytesRemaining = body.length - nextByteToRead;
+          if (bytesRemaining == 0) {
             // This should never happen - for known body length we shouldn't be called at all
             // if there's no more data to read.
             throw new IllegalStateException("The source has been exhausted but we expected more!");
           }
+
+          int bytesToRead = Math.min(byteBuffer.remaining(), bytesRemaining);
+          byteBuffer.put(body, nextByteToRead, bytesToRead);
+          nextByteToRead += bytesToRead;
+
           uploadDataSink.onReadSucceeded(false);
         }
 
         @Override
         public void rewind(UploadDataSink uploadDataSink) {
-          // TODO(danstahr): OkHttp 4 can use isOneShot flag here and rewind safely.
-          uploadDataSink.onRewindError(new UnsupportedOperationException());
+          nextByteToRead = 0;
+          uploadDataSink.onRewindSucceeded();
+        }
+
+        private void ensureMaterialized() throws IOException {
+          if (materializedBody != null) {
+            return;
+          }
+
+          Buffer buffer = new Buffer();
+          requestBody.writeTo(buffer);
+          // The user (RequestBody#writeTo) is done writing the request body.
+          // At this point, the user might or might not have attempted to close the sink.
+          // However, since we're using an okio.Buffer, it doesn't matter. Because okio.Buffer
+          // is an in-memory buffer, and calling close() on it is a no-op. Furthermore, we don't
+          // need to flush() the buffer, because it is already in memory.
+
+          long reportedLength = getLength();
+          long actualLength = buffer.size();
+          if (actualLength != reportedLength) {
+            throw new IOException("Expected " + reportedLength + " bytes but got " + actualLength);
+          }
+
+          materializedBody = buffer.readByteArray();
         }
       };
     }

--- a/javatests/com/google/net/cronet/okhttptransport/CronetInterceptorEndToEndTest.java
+++ b/javatests/com/google/net/cronet/okhttptransport/CronetInterceptorEndToEndTest.java
@@ -229,6 +229,50 @@ public class CronetInterceptorEndToEndTest {
   }
 
   @Test
+  public void testRedirectStrategy_with307Redirect_replaysSmallPostBody() throws Exception {
+    byte[] redirectBody = "Replay this body".getBytes(UTF_8);
+    server.setDispatcher(
+        new Dispatcher() {
+          @Override
+          public MockResponse dispatch(RecordedRequest request) {
+            if (request.getRequestUrl().encodedPath().equals("/start")) {
+              return new MockResponse().setResponseCode(307).addHeader("Location", "/redirected");
+            }
+            return ECHO_RESPONSE_DISPATCHER.dispatch(request);
+          }
+        });
+
+    OkHttpClient client = new OkHttpClient.Builder().addInterceptor(underTest).build();
+
+    Request request =
+        new Request.Builder()
+            .post(RequestBody.create(UTF_8_TEXT, redirectBody))
+            .url(server.url("/start"))
+            .build();
+
+    try (Response response = client.newCall(request).execute()) {
+      assertThat(response.protocol()).isEqualTo(Protocol.HTTP_1_0);
+      assertThat(response.code()).isEqualTo(200);
+      assertThat(response.request().url().encodedPath()).isEqualTo("/redirected");
+      assertThat(response.priorResponse().request().url().encodedPath()).isEqualTo("/start");
+      assertThat(response.headers("x-request-http-method")).containsExactly("POST");
+      assertThat(response.body().bytes()).isEqualTo(redirectBody);
+    }
+
+    RecordedRequest initialRequest = server.takeRequest(5, SECONDS);
+    assertThat(initialRequest).isNotNull();
+    assertThat(initialRequest.getPath()).isEqualTo("/start");
+    assertThat(initialRequest.getMethod()).isEqualTo("POST");
+    assertThat(initialRequest.getBody().readByteArray()).isEqualTo(redirectBody);
+
+    RecordedRequest redirectedRequest = server.takeRequest(5, SECONDS);
+    assertThat(redirectedRequest).isNotNull();
+    assertThat(redirectedRequest.getPath()).isEqualTo("/redirected");
+    assertThat(redirectedRequest.getMethod()).isEqualTo("POST");
+    assertThat(redirectedRequest.getBody().readByteArray()).isEqualTo(redirectBody);
+  }
+
+  @Test
   public void testRedirectStrategy_withRedirects_cycle() throws Exception {
     for (int i = 0; i < 9; i++) {
       server.enqueue(

--- a/javatests/com/google/net/cronet/okhttptransport/RequestBodyConverterTest.java
+++ b/javatests/com/google/net/cronet/okhttptransport/RequestBodyConverterTest.java
@@ -189,6 +189,21 @@ public class RequestBodyConverterTest {
   }
 
   @Test
+  public void testInMemory_knownLength_rewindReplaysBodyWithoutRewritingRequestBody()
+      throws Exception {
+    RequestBodyConverter converter = new InMemoryRequestBodyConverter();
+
+    byte[] content = TestUtils.generateRandomBytesArray(KB_56);
+    TestRequestBody requestBody = new TestRequestBody(content);
+    UploadDataProvider provider = converter.convertRequestBody(requestBody, NO_TIMEOUT);
+
+    assertThat(readAll(provider)).isEqualTo(content);
+    rewind(provider);
+    assertThat(readAll(provider)).isEqualTo(content);
+    assertThat(requestBody.getWriteCount()).isEqualTo(1);
+  }
+
+  @Test
   public void testStreaming_unknownLength_closeSinkAfterWrite() throws Exception {
     RequestBodyConverter converter =
         new StreamingRequestBodyConverter(Executors.newSingleThreadExecutor());
@@ -243,11 +258,18 @@ public class RequestBodyConverterTest {
     return buffer.readByteArray();
   }
 
+  private static void rewind(UploadDataProvider uploadDataProvider) throws Exception {
+    TestUploadDataSink sink = new TestUploadDataSink();
+    uploadDataProvider.rewind(sink);
+    sink.waitForRewindCallback();
+  }
+
   private static final class TestRequestBody extends RequestBody {
 
     private final byte[] content;
     private final long contentLength;
     private final boolean closeSinkAfterWrite;
+    private int writeCount;
 
     TestRequestBody(byte[] content) {
       this(content, content.length, false);
@@ -275,25 +297,31 @@ public class RequestBodyConverterTest {
 
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
+      writeCount++;
       sink.write(content);
       if (closeSinkAfterWrite) {
         sink.close();
       }
     }
+
+    private int getWriteCount() {
+      return writeCount;
+    }
   }
 
   private static final class TestUploadDataSink extends UploadDataSink {
 
-    private final SettableFuture<Boolean> result = SettableFuture.create();
+    private final SettableFuture<Boolean> readResult = SettableFuture.create();
+    private final SettableFuture<Void> rewindResult = SettableFuture.create();
 
     @Override
     public void onReadSucceeded(boolean finalChunk) {
-      result.set(finalChunk);
+      readResult.set(finalChunk);
     }
 
     @Override
     public void onReadError(Exception exception) {
-      result.setException(exception);
+      readResult.setException(exception);
     }
 
     /**
@@ -301,17 +329,21 @@ public class RequestBodyConverterTest {
      * and returns the value of {@code finalChunk} from {@code onReadSucceeded}.
      */
     private boolean waitForCallback() throws ExecutionException {
-      return Uninterruptibles.getUninterruptibly(result);
+      return Uninterruptibles.getUninterruptibly(readResult);
     }
 
     @Override
     public void onRewindSucceeded() {
-      throw new UnsupportedOperationException();
+      rewindResult.set(null);
     }
 
     @Override
     public void onRewindError(Exception exception) {
-      throw new UnsupportedOperationException();
+      rewindResult.setException(exception);
+    }
+
+    private void waitForRewindCallback() throws ExecutionException {
+      Uninterruptibles.getUninterruptibly(rewindResult);
     }
   }
 }


### PR DESCRIPTION
Fixes #44.

This change makes small in-memory request bodies rewindable so redirects that require replaying the request body can succeed.

It also adds:
- unit coverage for rewinding in-memory request bodies
- an end-to-end regression test for a 307 redirect preserving POST body
